### PR TITLE
ci: GHA workflow security cleanup

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -37,8 +37,10 @@ jobs:
         poetry-version: '2.1.4'
 
     - name: Setup a local virtual environment
+      env:
+        PYTHON_PATH: ${{ steps.setup-python.outputs.python-path }}
       run: |
-        poetry env use ${{ steps.setup-python.outputs.python-path }}
+        poetry env use "$PYTHON_PATH"
         poetry run python --version
         poetry config virtualenvs.create true --local
         poetry config virtualenvs.in-project true --local

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -19,6 +19,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
+        persist-credentials: false
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -7,9 +7,13 @@ on:
     branches:
       - main
 
+permissions: {}
+
 jobs:
   check:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -20,19 +20,19 @@ jobs:
         python-version: ['3.9', '3.10', '3.11', '3.12']
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         submodules: true
         persist-credentials: false
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
       id: setup-python
       with:
         python-version: ${{ matrix.python-version }}
 
     - name: Setup poetry
-      uses: abatilo/actions-poetry@v4
+      uses: abatilo/actions-poetry@0dd19c9498c3dc8728967849d0d2eae428a8a3d8 # v4
       with:
         poetry-version: '2.1.4'
 
@@ -45,7 +45,7 @@ jobs:
         poetry config virtualenvs.create true --local
         poetry config virtualenvs.in-project true --local
 
-    - uses: actions/cache@v4
+    - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       name: Define a cache for the virtual environment based on the dependencies lock file
       id: cache
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,10 +6,14 @@ on:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+*'
 
+permissions: {}
+
 jobs:
   build:
     name: Build distribution 📦
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
+          persist-credentials: false
 
       - name: Set up Python 3.12
         uses: actions/setup-python@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,8 +33,10 @@ jobs:
           poetry-version: '2.1.4'
 
       - name: Setup a local virtual environment
+        env:
+          PYTHON_PATH: ${{ steps.setup-python.outputs.python-path }}
         run: |
-          poetry env use ${{ steps.setup-python.outputs.python-path }}
+          poetry env use "$PYTHON_PATH"
           poetry run python --version
           poetry config virtualenvs.create true --local
           poetry config virtualenvs.in-project true --local

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,18 +41,6 @@ jobs:
           poetry config virtualenvs.create true --local
           poetry config virtualenvs.in-project true --local
 
-      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
-        name: Define a cache for the virtual environment based on the dependencies lock file
-        id: cache
-        with:
-          path: ./.venv
-          key: venv-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}
-
-      - name: Ensure cache is healthy
-        if: steps.cache.outputs.cache-hit == 'true'
-        shell: bash
-        run: poetry run pip --version >/dev/null 2>&1 || (echo "Cache is broken, skip it" && rm -rf .venv)
-
       - name: Install dependencies
         run: poetry install
       - name: Build a binary wheel and a source tarball

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,19 +16,19 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           submodules: true
           persist-credentials: false
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         id: setup-python
         with:
           python-version: 3.12
 
       - name: Setup poetry
-        uses: abatilo/actions-poetry@v4
+        uses: abatilo/actions-poetry@0dd19c9498c3dc8728967849d0d2eae428a8a3d8 # v4
         with:
           poetry-version: '2.1.4'
 
@@ -41,7 +41,7 @@ jobs:
           poetry config virtualenvs.create true --local
           poetry config virtualenvs.in-project true --local
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         name: Define a cache for the virtual environment based on the dependencies lock file
         id: cache
         with:
@@ -58,7 +58,7 @@ jobs:
       - name: Build a binary wheel and a source tarball
         run: poetry build
       - name: Store the distribution packages
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: python-package-distributions
           path: dist/
@@ -77,7 +77,7 @@ jobs:
 
     steps:
       - name: Download all the dists
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: python-package-distributions
           path: dist/
@@ -104,7 +104,7 @@ jobs:
           VERSION: ${{ steps.version.outputs.version }}
           TAG: ${{ steps.tag.outputs.tag }}
       - name: Publish distribution 📦 to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
 
   publish-to-testpypi:
     name: Publish Python distribution to TestPyPI
@@ -121,11 +121,11 @@ jobs:
 
     steps:
       - name: Download all the dists
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: python-package-distributions
           path: dist/
       - name: Publish distribution 📦 to TestPyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           repository-url: https://test.pypi.org/legacy/


### PR DESCRIPTION
Routine hygiene pass over the GitHub Actions workflows in this repo, addressing findings from a workflow security audit. Changes are split into five commits, one per finding type:

 - Disable credential persistence on actions/checkout steps so the default GITHUB_TOKEN is not left in the local git config after checkout.
 - Scope each job's permissions explicitly: top-level permissions: {}, with each job granted only the GITHUB_TOKEN scopes it actually needs (contents: read for check + build; the
 existing id-token: write is retained on the publish jobs).
 - Move workflow-context expansions (${{ steps.setup-python.outputs.python-path }}) out of run: shell source and into env: bindings.
 - Pin all third-party actions to commit SHAs (with the tag preserved as a trailing comment) so an upstream tag move can't silently change what runs in CI.
 - Drop the venv cache from the release workflow. Caches restored into the build that produces published artifacts are a poisoning vector, and the cache key referenced ${{
 matrix.python-version }} from a non-matrix job so it was resolving to an empty segment anyway. The check workflow still caches the venv across PR/push runs.

 No behavioural changes intended — the workflows run the same checks against the same inputs.